### PR TITLE
golint の設定を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,13 @@ executors:
           TZ: "Asia/Tokyo"
           GOPATH: &gopath "/home/circleci/go"
 
+  golangci_lint:
+    working_directory: *working_directory
+    docker:
+      - image: golangci/golangci-lint
+        environment:
+          GOPATH: *gopath
+
 commands:
   restore_source_cache:
     steps:
@@ -66,6 +73,26 @@ jobs:
           command: |
             go test -v ./...
 
+  lint_go:
+    executor: golangci_lint
+    steps:
+      - restore_source_cache
+      - checkout
+      - restore_go_cache
+      - run:
+          name: run golangci-lint
+          command: |
+            golangci-lint run --disable-all \
+              -E govet \
+              -E errcheck \
+              -E staticcheck \
+              -E golint \
+              -E unconvert \
+              -E goimports \
+              -E misspell \
+              -E unparam \
+              -E prealloc \
+
 workflows:
   version: 2
   test:
@@ -75,5 +102,14 @@ workflows:
           requires:
             - prepare_source
       - test_go:
+          requires:
+            - prepare_go
+  lint:
+    jobs:
+      - prepare_source
+      - prepare_go:
+          requires:
+            - prepare_source
+      - lint_go:
           requires:
             - prepare_go


### PR DESCRIPTION
[golangci_lint](https://github.com/golangci/golangci-lint#supported-linters) を ci に組み込む
実行される静的解析は以下

- govet（引数がフォーマットと一致しない printf を報告）
- errcheck（error をチェックしていないコードを報告）
- staticcheck (静的解析する内容が増やせるっぽい)
- golint（format せずに format されていないコードを報告）
- uncovert （不要な型変換）
- goimports (コードがgoimportsでフォーマットされてるかチェック)
- misspell (綴が間違えていないかチェック)
- unparam（使用されていない関数の値を報告）
- prealloc（事前に割り当てられる可能性のあるスライスを報告）

並び順は公式と共通にした

- [x] ci が正常に動作

close #11 
