### PR TITLE
CSV出力、読み込みをSJIS,BOM付きUTF8両対応 refs #16

### DIFF
--- a/interop/excel/csv/csv.go
+++ b/interop/excel/csv/csv.go
@@ -39,7 +39,7 @@ func NewReader(r io.Reader) *csv.Reader {
 // NewSJISWriter 与えられたio.Writerを元に新しいSJISのcsvライターを返す。UseCRLFはデフォルトでtrueが設定される
 func NewSJISWriter(w io.Writer) *csv.Writer {
 	if _, ok := w.(*bufio.Writer); ok {
-		panic("Can't use *bufio.Writer in SJIS")
+		panic("Can't use *bufio.Writer")
 
 	}
 	writer := csv.NewWriter(transform.NewWriter(w, japanese.ShiftJIS.NewEncoder()))
@@ -49,6 +49,9 @@ func NewSJISWriter(w io.Writer) *csv.Writer {
 
 // NewUTF8WithBOMWriter 与えられたio.Writerを元に新しいBOM付きUTF8のcsvライターを返す。UseCRLFはデフォルトでtrueが設定される
 func NewUTF8WithBOMWriter(w io.Writer) *csv.Writer {
+	if _, ok := w.(*bufio.Writer); ok {
+		panic("Can't use *bufio.Writer")
+	}
 	writer := csv.NewWriter(&utf8WithBOMByteWriter{
 		wroteBOM: false,
 		writer:   w,

--- a/interop/excel/csv/csv.go
+++ b/interop/excel/csv/csv.go
@@ -4,18 +4,108 @@ import (
 	"encoding/csv"
 	"io"
 
+	"bytes"
+
 	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/transform"
 )
 
-// NewReader 与えられたio.Readerを元に新しいcsvリーダーを返す
-func NewReader(r io.Reader) *csv.Reader {
+// UTF8BOM UTF8のBOM
+var UTF8BOM = [3]byte{0xEF, 0xBB, 0xBF}
+
+// NewUTF8WithBOMReader BOM付きUTF8のリーダーを新しく作る
+func NewUTF8WithBOMReader(r io.Reader) *csv.Reader {
+	return csv.NewReader(&utf8WIthBOMByteReader{
+		readBOM: false,
+		reader:  r,
+	})
+}
+
+// NewSJISReader 与えられたio.Readerを元に新しいリーダーを返す
+func NewSJISReader(r io.Reader) *csv.Reader {
 	return csv.NewReader(transform.NewReader(r, japanese.ShiftJIS.NewDecoder()))
 }
 
-// NewWriter 与えられたio.Writerを元に新しいcsvライターを返す。UseCRLFはデフォルトでtrueが設定される
-func NewWriter(w io.Writer) *csv.Writer {
+// NewReader 与えられたio.Readerを元に新しいcsvリーダーを返す
+func NewReader(r io.Reader) *csv.Reader {
+	return csv.NewReader(&hybridByteReader{
+		readBOM: false,
+		reader:  r,
+	})
+}
+
+// NewSJISWriter 与えられたio.Writerを元に新しいSJISのcsvライターを返す。UseCRLFはデフォルトでtrueが設定される
+func NewSJISWriter(w io.Writer) *csv.Writer {
 	writer := csv.NewWriter(transform.NewWriter(w, japanese.ShiftJIS.NewEncoder()))
 	writer.UseCRLF = true
 	return writer
+}
+
+// NewUTF8WithBOMWriter 与えられたio.Writerを元に新しいBOM付きUTF8のcsvライターを返す。UseCRLFはデフォルトでtrueが設定される
+func NewUTF8WithBOMWriter(w io.Writer) *csv.Writer {
+	writer := csv.NewWriter(&utf8WithBOMByteWriter{
+		wroteBOM: false,
+		writer:   w,
+	})
+	writer.UseCRLF = true
+	return writer
+}
+
+type utf8WithBOMByteWriter struct {
+	wroteBOM bool
+	writer   io.Writer
+}
+
+func (u *utf8WithBOMByteWriter) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if !u.wroteBOM {
+		n, err := u.writer.Write(UTF8BOM[:])
+		u.wroteBOM = true
+		if err != nil {
+			return n, err
+		}
+	}
+	return u.writer.Write(p)
+}
+
+type utf8WIthBOMByteReader struct {
+	readBOM bool
+	reader  io.Reader
+}
+
+func (u *utf8WIthBOMByteReader) Read(p []byte) (int, error) {
+	if !u.readBOM {
+		bom := [len(UTF8BOM)]byte{}
+		n, err := u.reader.Read(bom[:])
+		u.readBOM = true
+		if err != nil {
+			return n, err
+		}
+	}
+	return u.reader.Read(p)
+}
+
+type hybridByteReader struct {
+	readBOM bool
+	reader  io.Reader
+}
+
+func (h *hybridByteReader) Read(p []byte) (int, error) {
+	if !h.readBOM {
+		bom := [len(UTF8BOM)]byte{}
+		utf8WithBOM := false
+		n, err := h.reader.Read(bom[:])
+		h.readBOM = true
+		if err != nil {
+			return n, err
+		} else if n >= len(UTF8BOM) && bytes.Equal(UTF8BOM[:], bom[:]) {
+			utf8WithBOM = true
+		}
+		if !utf8WithBOM {
+			h.reader = transform.NewReader(io.MultiReader(bytes.NewReader(bom[:]), h.reader), japanese.ShiftJIS.NewDecoder())
+		}
+	}
+	return h.reader.Read(p)
 }

--- a/interop/excel/csv/csv_test.go
+++ b/interop/excel/csv/csv_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/topgate/goutils/reflect"
 	"golang.org/x/text/encoding/japanese"
 )
 
@@ -35,6 +36,23 @@ func TestReaders(t *testing.T) {
 				"値1,値2,値3\r\n",
 		},
 		{
+			"最終行改行ありCRなし",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\n" +
+				"値1,値2,値3\n",
+		},
+		{
 			"最終行改行なし",
 			[][]string{
 				{
@@ -52,6 +70,23 @@ func TestReaders(t *testing.T) {
 				"値1,値2,値3",
 		},
 		{
+			"最終行改行なしCRなし",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\n" +
+				"値1,値2,値3",
+		},
+		{
 			"empty",
 			nil,
 			"",
@@ -60,11 +95,10 @@ func TestReaders(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			assertions := assert.New(t)
-			testReader(assertions, tt.expected, tt.given, NewSJISReader, toSJIS)
-			testReader(assertions, tt.expected, tt.given, NewReader, toSJIS)
-			testReader(assertions, tt.expected, tt.given, NewReader, toUTF8WithBOM)
-			testReader(assertions, tt.expected, tt.given, NewUTF8WithBOMReader, toUTF8WithBOM)
+			testReader(t, tt.expected, tt.given, NewSJISReader, toSJIS)
+			testReader(t, tt.expected, tt.given, NewReader, toSJIS)
+			testReader(t, tt.expected, tt.given, NewReader, toUTF8WithBOM)
+			testReader(t, tt.expected, tt.given, NewUTF8WithBOMReader, toUTF8WithBOM)
 		})
 	}
 }
@@ -101,46 +135,54 @@ func TestWriters(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			assertions := assert.New(t)
-			testWriter(assertions, tt.expected, tt.given, NewUTF8WithBOMWriter, toUTF8WithBOM)
-			testWriter(assertions, tt.expected, tt.given, NewSJISWriter, toSJIS)
+			testWriter(t, tt.expected, tt.given, NewUTF8WithBOMWriter, toUTF8WithBOM)
+			testWriter(t, tt.expected, tt.given, NewSJISWriter, toSJIS)
 		})
 	}
 }
-func testReader(assertions *assert.Assertions, expected [][]string, given string, generator func(io.Reader) *csv.Reader, strConverter func(string) []byte) {
-	reader := generator(bytes.NewReader(strConverter(given)))
-	actual, err := reader.ReadAll()
-	if !assertions.NoError(err) {
-		return
-	}
-	assertions.EqualValues(expected, actual)
+func testReader(t *testing.T, expected [][]string, given string, generator func(io.Reader) *csv.Reader, strConverter func(string) []byte) {
+	t.Run(reflect.GetFunctionName(generator)+":"+reflect.GetFunctionName(strConverter), func(t *testing.T) {
+		assertions := assert.New(t)
+		reader := generator(bytes.NewReader(strConverter(given)))
 
-	individualReader := generator(bytes.NewReader(strConverter(given)))
-
-	index := 0
-	for line, err := individualReader.Read(); err != io.EOF; line, err = individualReader.Read() {
+		actual, err := reader.ReadAll()
 		if !assertions.NoError(err) {
-			break
+			return
 		}
-		assertions.EqualValues(expected[index], line)
-		index++
-	}
+		assertions.EqualValues(expected, actual)
+
+		individualReader := generator(bytes.NewReader(strConverter(given)))
+
+		index := 0
+		for line, err := individualReader.Read(); err != io.EOF; line, err = individualReader.Read() {
+			if !assertions.NoError(err) {
+				break
+			}
+			assertions.EqualValues(expected[index], line)
+			index++
+		}
+	})
 
 }
 
-func testWriter(assertions *assert.Assertions, expected string, given [][]string, generator func(io.Writer) *csv.Writer, strConverter func(string) []byte) {
-	iw := &bytes.Buffer{}
-	writer := generator(iw)
-	err := writer.WriteAll(given)
-	if !assertions.NoError(err) {
-		return
-	}
-	if len(expected) > 0 {
-		expectedBytes := strConverter(expected)
-		assertions.EqualValues(expectedBytes, iw.Bytes())
-	} else {
-		assertions.Empty(iw.Bytes())
-	}
+func testWriter(t *testing.T, expected string, given [][]string, generator func(io.Writer) *csv.Writer, strConverter func(string) []byte) {
+
+	t.Run(reflect.GetFunctionName(generator)+":"+reflect.GetFunctionName(strConverter), func(t *testing.T) {
+		assertions := assert.New(t)
+		iw := &bytes.Buffer{}
+		writer := generator(iw)
+		err := writer.WriteAll(given)
+		if !assertions.NoError(err) {
+			return
+		}
+		if len(expected) > 0 {
+			expectedBytes := strConverter(expected)
+			assertions.EqualValues(expectedBytes, iw.Bytes())
+		} else {
+			assertions.Empty(iw.Bytes())
+		}
+
+	})
 }
 
 func toSJIS(str string) []byte {

--- a/interop/excel/csv/csv_test.go
+++ b/interop/excel/csv/csv_test.go
@@ -1,6 +1,8 @@
 package csv
 
 import (
+	"encoding/csv"
+	"io"
 	"testing"
 
 	"bytes"
@@ -9,7 +11,7 @@ import (
 	"golang.org/x/text/encoding/japanese"
 )
 
-func TestNewReaderAsSJIS(t *testing.T) {
+func TestReaders(t *testing.T) {
 	var tests = []struct {
 		name     string
 		expected [][]string
@@ -59,215 +61,15 @@ func TestNewReaderAsSJIS(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assertions := assert.New(t)
-			encoder := japanese.ShiftJIS.NewEncoder()
-			given, err := encoder.Bytes([]byte(tt.given))
-			if !assertions.NoError(err) {
-				return
-			}
-			reader := NewReader(bytes.NewReader(given))
-			if !assertions.NoError(err) {
-				return
-			}
-			actual, err := reader.ReadAll()
-			if !assertions.NoError(err) {
-				return
-			}
-			assertions.EqualValues(tt.expected, actual)
+			testReader(assertions, tt.expected, tt.given, NewSJISReader, toSJIS)
+			testReader(assertions, tt.expected, tt.given, NewReader, toSJIS)
+			testReader(assertions, tt.expected, tt.given, NewReader, toUTF8WithBOM)
+			testReader(assertions, tt.expected, tt.given, NewUTF8WithBOMReader, toUTF8WithBOM)
 		})
 	}
 }
 
-func TestNewSJISReader(t *testing.T) {
-	var tests = []struct {
-		name     string
-		expected [][]string
-		given    string
-	}{
-		{
-			"最終行改行あり",
-			[][]string{
-				{
-					"ヘッダー１",
-					"ヘッダー２",
-					"ヘッダー３",
-				},
-				{
-					"値1",
-					"値2",
-					"値3",
-				},
-			},
-			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
-				"値1,値2,値3\r\n",
-		},
-		{
-			"最終行改行なし",
-			[][]string{
-				{
-					"ヘッダー１",
-					"ヘッダー２",
-					"ヘッダー３",
-				},
-				{
-					"値1",
-					"値2",
-					"値3",
-				},
-			},
-			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
-				"値1,値2,値3",
-		},
-		{
-			"empty",
-			nil,
-			"",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assertions := assert.New(t)
-			encoder := japanese.ShiftJIS.NewEncoder()
-			given, err := encoder.Bytes([]byte(tt.given))
-			if !assertions.NoError(err) {
-				return
-			}
-			reader := NewSJISReader(bytes.NewReader(given))
-			if !assertions.NoError(err) {
-				return
-			}
-			actual, err := reader.ReadAll()
-			if !assertions.NoError(err) {
-				return
-			}
-			assertions.EqualValues(tt.expected, actual)
-		})
-	}
-}
-func TestNewReaderASUTF8WithBOM(t *testing.T) {
-
-	var tests = []struct {
-		name     string
-		expected [][]string
-		given    string
-	}{
-		{
-			"最終行改行あり",
-			[][]string{
-				{
-					"ヘッダー１",
-					"ヘッダー２",
-					"ヘッダー３",
-				},
-				{
-					"値1",
-					"値2",
-					"値3",
-				},
-			},
-			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
-				"値1,値2,値3\r\n",
-		},
-		{
-			"最終行改行なし",
-			[][]string{
-				{
-					"ヘッダー１",
-					"ヘッダー２",
-					"ヘッダー３",
-				},
-				{
-					"値1",
-					"値2",
-					"値3",
-				},
-			},
-			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
-				"値1,値2,値3",
-		},
-		{
-			"empty",
-			nil,
-			"",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assertions := assert.New(t)
-			given := append(UTF8BOM[:], []byte(tt.given)...)
-			reader := NewReader(bytes.NewReader(given))
-			actual, err := reader.ReadAll()
-			if !assertions.NoError(err) {
-				return
-			}
-			assertions.EqualValues(tt.expected, actual)
-		})
-	}
-}
-
-func TestNewUTF8WithBOMReader(t *testing.T) {
-
-	var tests = []struct {
-		name     string
-		expected [][]string
-		given    string
-	}{
-		{
-			"最終行改行あり",
-			[][]string{
-				{
-					"ヘッダー１",
-					"ヘッダー２",
-					"ヘッダー３",
-				},
-				{
-					"値1",
-					"値2",
-					"値3",
-				},
-			},
-			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
-				"値1,値2,値3\r\n",
-		},
-		{
-			"最終行改行なし",
-			[][]string{
-				{
-					"ヘッダー１",
-					"ヘッダー２",
-					"ヘッダー３",
-				},
-				{
-					"値1",
-					"値2",
-					"値3",
-				},
-			},
-			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
-				"値1,値2,値3",
-		},
-		{
-			"empty",
-			nil,
-			"",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assertions := assert.New(t)
-			given := append(UTF8BOM[:], []byte(tt.given)...)
-			reader := NewUTF8WithBOMReader(bytes.NewReader(given))
-			actual, err := reader.ReadAll()
-			if !assertions.NoError(err) {
-				return
-			}
-			assertions.EqualValues(tt.expected, actual)
-		})
-	}
-}
-func TestNewSJISWriter(t *testing.T) {
+func TestWriters(t *testing.T) {
 	var tests = []struct {
 		name     string
 		expected string
@@ -300,75 +102,56 @@ func TestNewSJISWriter(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assertions := assert.New(t)
-			iw := bytes.Buffer{}
-			writer := NewSJISWriter(&iw)
-			err := writer.WriteAll(tt.given)
-			if !assertions.NoError(err) {
-				return
-			}
-			var expected []byte
-			if len(tt.expected) > 0 {
-				encoder := japanese.ShiftJIS.NewEncoder()
-				expected, err = encoder.Bytes([]byte(tt.expected))
-				if !assertions.NoError(err) {
-					return
-				}
-			} else {
-				expected = nil
-			}
-
-			assertions.EqualValues(expected, iw.Bytes())
+			testWriter(assertions, tt.expected, tt.given, NewUTF8WithBOMWriter, toUTF8WithBOM)
+			testWriter(assertions, tt.expected, tt.given, NewSJISWriter, toSJIS)
 		})
 	}
 }
-func TestNewUTF8WithBOMWriter(t *testing.T) {
-	var tests = []struct {
-		name     string
-		expected string
-		given    [][]string
-	}{
-		{
-			"正常系",
-			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
-				"値1,値2,値3\r\n",
-			[][]string{
-				{
-					"ヘッダー１",
-					"ヘッダー２",
-					"ヘッダー３",
-				},
-				{
-					"値1",
-					"値2",
-					"値3",
-				},
-			},
-		},
-		{
-			"empty",
-			"",
-			nil,
-		},
+func testReader(assertions *assert.Assertions, expected [][]string, given string, generator func(io.Reader) *csv.Reader, strConverter func(string) []byte) {
+	reader := generator(bytes.NewReader(strConverter(given)))
+	actual, err := reader.ReadAll()
+	if !assertions.NoError(err) {
+		return
+	}
+	assertions.EqualValues(expected, actual)
+
+	individualReader := generator(bytes.NewReader(strConverter(given)))
+
+	index := 0
+	for line, err := individualReader.Read(); err != io.EOF; line, err = individualReader.Read() {
+		if !assertions.NoError(err) {
+			break
+		}
+		assertions.EqualValues(expected[index], line)
+		index++
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assertions := assert.New(t)
-			iw := bytes.Buffer{}
-			writer := NewUTF8WithBOMWriter(&iw)
-			err := writer.WriteAll(tt.given)
-			if !assertions.NoError(err) {
-				return
-			}
-			var expected []byte
-			if len(tt.expected) > 0 {
-				expected = append(UTF8BOM[:], tt.expected...)
+}
 
-			} else {
-				expected = nil
-			}
-			assertions.EqualValues(expected, iw.Bytes())
-		})
+func testWriter(assertions *assert.Assertions, expected string, given [][]string, generator func(io.Writer) *csv.Writer, strConverter func(string) []byte) {
+	iw := &bytes.Buffer{}
+	writer := generator(iw)
+	err := writer.WriteAll(given)
+	if !assertions.NoError(err) {
+		return
 	}
+	if len(expected) > 0 {
+		expectedBytes := strConverter(expected)
+		assertions.EqualValues(expectedBytes, iw.Bytes())
+	} else {
+		assertions.Empty(iw.Bytes())
+	}
+}
+
+func toSJIS(str string) []byte {
+	encoder := japanese.ShiftJIS.NewEncoder()
+	result, err := encoder.Bytes([]byte(str))
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func toUTF8WithBOM(str string) []byte {
+	return append(UTF8BOM[:], []byte(str)...)
 }

--- a/interop/excel/csv/csv_test.go
+++ b/interop/excel/csv/csv_test.go
@@ -170,17 +170,17 @@ func TestUTF8WithBOMReader_InvalidCases(t *testing.T) {
 	}
 }
 
-func TestSJISWriter_PanicCases(t *testing.T) {
+func TestWriter_PanicCases(t *testing.T) {
 	var tests = []struct {
 		name     string
 		expected string
 		given    io.Writer
 	}{
-		{"*bufio.Writer", "Can't use *bufio.Writer in SJIS", bufio.NewWriter(&bytes.Buffer{})},
+		{"*bufio.Writer", "Can't use *bufio.Writer", bufio.NewWriter(&bytes.Buffer{})},
 	}
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name+":"+reflect.GetFunctionName(NewSJISWriter), func(t *testing.T) {
 			assertions := assert.New(t)
 			defer func() {
 				err := recover()
@@ -188,6 +188,15 @@ func TestSJISWriter_PanicCases(t *testing.T) {
 			}()
 
 			NewSJISWriter(tt.given)
+		})
+		t.Run(tt.name+":"+reflect.GetFunctionName(NewUTF8WithBOMWriter), func(t *testing.T) {
+			assertions := assert.New(t)
+			defer func() {
+				err := recover()
+				assertions.EqualValues(tt.expected, err)
+			}()
+
+			NewUTF8WithBOMWriter(tt.given)
 		})
 	}
 }

--- a/interop/excel/csv/csv_test.go
+++ b/interop/excel/csv/csv_test.go
@@ -9,7 +9,142 @@ import (
 	"golang.org/x/text/encoding/japanese"
 )
 
-func TestNewReader(t *testing.T) {
+func TestNewReaderAsSJIS(t *testing.T) {
+	var tests = []struct {
+		name     string
+		expected [][]string
+		given    string
+	}{
+		{
+			"最終行改行あり",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
+				"値1,値2,値3\r\n",
+		},
+		{
+			"最終行改行なし",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
+				"値1,値2,値3",
+		},
+		{
+			"empty",
+			nil,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			encoder := japanese.ShiftJIS.NewEncoder()
+			given, err := encoder.Bytes([]byte(tt.given))
+			if !assertions.NoError(err) {
+				return
+			}
+			reader := NewReader(bytes.NewReader(given))
+			if !assertions.NoError(err) {
+				return
+			}
+			actual, err := reader.ReadAll()
+			if !assertions.NoError(err) {
+				return
+			}
+			assertions.EqualValues(tt.expected, actual)
+		})
+	}
+}
+
+func TestNewSJISReader(t *testing.T) {
+	var tests = []struct {
+		name     string
+		expected [][]string
+		given    string
+	}{
+		{
+			"最終行改行あり",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
+				"値1,値2,値3\r\n",
+		},
+		{
+			"最終行改行なし",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
+				"値1,値2,値3",
+		},
+		{
+			"empty",
+			nil,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			encoder := japanese.ShiftJIS.NewEncoder()
+			given, err := encoder.Bytes([]byte(tt.given))
+			if !assertions.NoError(err) {
+				return
+			}
+			reader := NewSJISReader(bytes.NewReader(given))
+			if !assertions.NoError(err) {
+				return
+			}
+			actual, err := reader.ReadAll()
+			if !assertions.NoError(err) {
+				return
+			}
+			assertions.EqualValues(tt.expected, actual)
+		})
+	}
+}
+func TestNewReaderASUTF8WithBOM(t *testing.T) {
 
 	var tests = []struct {
 		name     string
@@ -50,16 +185,17 @@ func TestNewReader(t *testing.T) {
 			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
 				"値1,値2,値3",
 		},
+		{
+			"empty",
+			nil,
+			"",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assertions := assert.New(t)
-			encoder := japanese.ShiftJIS.NewEncoder()
-			given, err := encoder.Bytes([]byte(tt.given))
-			if !assertions.NoError(err) {
-				return
-			}
+			given := append(UTF8BOM[:], []byte(tt.given)...)
 			reader := NewReader(bytes.NewReader(given))
 			actual, err := reader.ReadAll()
 			if !assertions.NoError(err) {
@@ -70,7 +206,68 @@ func TestNewReader(t *testing.T) {
 	}
 }
 
-func TestNewWriter(t *testing.T) {
+func TestNewUTF8WithBOMReader(t *testing.T) {
+
+	var tests = []struct {
+		name     string
+		expected [][]string
+		given    string
+	}{
+		{
+			"最終行改行あり",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
+				"値1,値2,値3\r\n",
+		},
+		{
+			"最終行改行なし",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
+				"値1,値2,値3",
+		},
+		{
+			"empty",
+			nil,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			given := append(UTF8BOM[:], []byte(tt.given)...)
+			reader := NewUTF8WithBOMReader(bytes.NewReader(given))
+			actual, err := reader.ReadAll()
+			if !assertions.NoError(err) {
+				return
+			}
+			assertions.EqualValues(tt.expected, actual)
+		})
+	}
+}
+func TestNewSJISWriter(t *testing.T) {
 	var tests = []struct {
 		name     string
 		expected string
@@ -93,23 +290,84 @@ func TestNewWriter(t *testing.T) {
 				},
 			},
 		},
+		{
+			"empty",
+			"",
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assertions := assert.New(t)
 			iw := bytes.Buffer{}
-			writer := NewWriter(&iw)
+			writer := NewSJISWriter(&iw)
 			err := writer.WriteAll(tt.given)
 			if !assertions.NoError(err) {
 				return
 			}
-			encoder := japanese.ShiftJIS.NewEncoder()
-			expected, err := encoder.Bytes([]byte(tt.expected))
+			var expected []byte
+			if len(tt.expected) > 0 {
+				encoder := japanese.ShiftJIS.NewEncoder()
+				expected, err = encoder.Bytes([]byte(tt.expected))
+				if !assertions.NoError(err) {
+					return
+				}
+			} else {
+				expected = nil
+			}
+
+			assertions.EqualValues(expected, iw.Bytes())
+		})
+	}
+}
+func TestNewUTF8WithBOMWriter(t *testing.T) {
+	var tests = []struct {
+		name     string
+		expected string
+		given    [][]string
+	}{
+		{
+			"正常系",
+			"ヘッダー１,ヘッダー２,ヘッダー３\r\n" +
+				"値1,値2,値3\r\n",
+			[][]string{
+				{
+					"ヘッダー１",
+					"ヘッダー２",
+					"ヘッダー３",
+				},
+				{
+					"値1",
+					"値2",
+					"値3",
+				},
+			},
+		},
+		{
+			"empty",
+			"",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			iw := bytes.Buffer{}
+			writer := NewUTF8WithBOMWriter(&iw)
+			err := writer.WriteAll(tt.given)
 			if !assertions.NoError(err) {
 				return
 			}
+			var expected []byte
+			if len(tt.expected) > 0 {
+				expected = append(UTF8BOM[:], tt.expected...)
 
+			} else {
+				expected = nil
+			}
 			assertions.EqualValues(expected, iw.Bytes())
 		})
 	}

--- a/interop/excel/csv/csv_test.go
+++ b/interop/excel/csv/csv_test.go
@@ -171,6 +171,7 @@ func testWriter(t *testing.T, expected string, given [][]string, generator func(
 		assertions := assert.New(t)
 		iw := &bytes.Buffer{}
 		writer := generator(iw)
+		assertions.True(writer.UseCRLF)
 		err := writer.WriteAll(given)
 		if !assertions.NoError(err) {
 			return

--- a/interop/excel/gocsv/gocsv.go
+++ b/interop/excel/gocsv/gocsv.go
@@ -14,5 +14,5 @@ func Unmarshal(r io.Reader, out interface{}) error {
 
 // Marshal returns  CSV in writer from the interface.
 func Marshal(in interface{}, w io.Writer) error {
-	return gocsv.MarshalCSV(in, gocsv.NewSafeCSVWriter(csv.NewWriter(w)))
+	return gocsv.MarshalCSV(in, gocsv.NewSafeCSVWriter(csv.NewUTF8WithBOMWriter(w)))
 }

--- a/reflect/function.go
+++ b/reflect/function.go
@@ -1,0 +1,19 @@
+package reflect
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+// GetFunctionName 関数名を取得する
+func GetFunctionName(i interface{}) string {
+	pationalNames := strings.Split(GetFunctionFullName(i), "/")
+	return pationalNames[len(pationalNames)-1]
+
+}
+
+// GetFunctionFullName 関数のフルネームを取得する
+func GetFunctionFullName(i interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}


### PR DESCRIPTION
- Writer にBOM付きUTF8での出力を選択できるようにする
- Reader にBOM付きUTF8での読み取りを選択できるようにする
- ReaderのデフォルトをBOMがあればUTF8で、なければSJISで読むようにする

Writerのデフォルトは無い方が良いと判断したので作らないようにした

close #16